### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The file was part of the initial commit, 
which apparently does not enable dependabot